### PR TITLE
Uplink Location html fix

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -699,7 +699,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			if((HAS_FLESH in pref_species.species_traits) || (HAS_BONE in pref_species.species_traits))
 				dat += "<BR><b>Temporal Scarring:</b><BR><a href='?_src_=prefs;preference=persistent_scars'>[(persistent_scars) ? "Enabled" : "Disabled"]</A>"
 				dat += "<a href='?_src_=prefs;preference=clear_scars'>Clear scar slots</A>"
-			dat += "<b>Uplink Location:</b><a style='display:block;width:100px' href ='?_src_=prefs;preference=uplink_loc;task=input'>[uplink_spawn_loc]</a>"
+			dat += "<BR><b>Uplink Location:</b><a style='display:block;width:100px' href ='?_src_=prefs;preference=uplink_loc;task=input'>[uplink_spawn_loc]</a>"
 			dat += "</td>"
 
 			dat +="<td width='220px' height='300px' valign='top'>"


### PR DESCRIPTION
Adds a line break so Uplink Location and Temporal Scarring options didn't occur on the same line

## About The Pull Request

Literally just adds a line break at the start of a string

## Why It's Good For The Game

Looks better, technically a graphical bug fix

## Changelog
:cl:
fix: line break at start of Uplink Location so it and Temporal Scarring options didn't occur on the same line
/:cl: