### PR TITLE
Re-adds the connect/disconnect message to admins

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -304,6 +304,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 	var/full_version = "[byond_version].[byond_build ? byond_build : "xxx"]"
 	log_access("Login: [key_name(src)] from [address ? address : "localhost"]-[computer_id] || BYOND v[full_version]")
+	message_admins("[key_name_admin(src)] has connected.") // Lumos Change - Login notification for admins
 
 	var/alert_mob_dupe_login = FALSE
 	if(CONFIG_GET(flag/log_access))
@@ -520,6 +521,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	GLOB.clients -= src
 	GLOB.directory -= ckey
 	log_access("Logout: [key_name(src)]")
+	message_admins("[key_name_admin(src)] has logged out.") // Lumos change - Logout notification for admins
 	GLOB.ahelp_tickets.ClientLogout(src)
 	SSserver_maint.UpdateHubStatus()
 	if(credits)


### PR DESCRIPTION
## About The Pull Request

Adds a message to admins whenever someone joins or leaves.

## Why It's Good For The Game

It's handy for admins seeing as we're typically lowpop so it's not going to spam us too much. Probably a better way to go about it. Might be worth adding a toggle for it for admins who'd rather not know or don't care.

## Changelog
:cl:
add: Join/Leave notifs for admins
/:cl:
