### PR TITLE
Set extend vote requirement to 0

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -253,7 +253,7 @@ SUBSYSTEM_DEF(vote)
 		calculate_highest_median(vote_title_text)
 	var/list/winners = list()
 	if(mode == "transfer")
-		var/amount_required = 1 + transfer_votes_done
+		var/amount_required = 0 // Lumos change
 		transfer_votes_done += 1
 		text += "\nExtending requires at least [amount_required] votes to win."
 		if(choices[VOTE_CONTINUE] < amount_required || choices[VOTE_TRANSFER] >= choices[VOTE_CONTINUE])


### PR DESCRIPTION
## About The Pull Request

Changes calculation for extending a transfer vote to zero. I see no way this could be bad.

## Why It's Good For The Game

I dunno

## Changelog
:cl:
tweak: transfer vote extending requirement to zero, as opposed to 1 + end round voters amt
/:cl: