### PR TITLE
Monkey Sprite (mapper fix)

### DIFF
--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -3,7 +3,7 @@
 	verb_say = "chimpers"
 	initial_language_holder = /datum/language_holder/monkey
 	icon = 'icons/mob/monkey.dmi'
-	icon_state = ""
+	icon_state = "monkey1"
 	gender = NEUTER
 	pass_flags = PASSTABLE
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID


### PR DESCRIPTION

Probably TM this first, might be a reason I haven't found for why monkey monkey funky sprites are the way they are

## About The Pull Request

Changes default iconstate of monkey to "monkey1" the proper monkey
monkey monkey monkey

## Why It's Good For The Game

Me and my monkey
Did I say monkey enough yet?

## Changelog
:cl:
add: "monkey1" to carbon/monkey icon_state
/:cl: